### PR TITLE
refactor(interfaces/models): rename interfaces and update paths for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
-
+.vscode
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,9 +2,9 @@ import express,{Request,Response,Express} from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import { connectBD } from './utils/mongodb';
-import { Usuario } from './interfaces/usuario.interface';
+import { IUsuario as Usuario } from './interfaces/usuario.interface';
 import { modelUsuario } from './models/usuario.model';
-import { Publicacion } from './interfaces/publicacion.interface';
+import { IPublicacion as Publicacion } from './interfaces/publicacion.interface';
 import { modelPublicacion } from './models/publicacion.model';
 
 const app: Express = express();

--- a/backend/src/interfaces/publicacion.interface.ts
+++ b/backend/src/interfaces/publicacion.interface.ts
@@ -1,9 +1,17 @@
 import { Document } from "mongoose";
 
-export interface Publicacion extends Document {
+export interface IPublicacion extends Document {
     titulo: string;
     contenido: string;
     autor: string;
     fecha: Date;
     adjunto: string[];
+    comentarios: IComentario[]; // Array de comentarios
+    tag: string;
+}
+
+export interface IComentario {
+    autor: string;
+    contenido: string;
+    fecha: Date;
 }

--- a/backend/src/interfaces/usuario.interface.ts
+++ b/backend/src/interfaces/usuario.interface.ts
@@ -1,6 +1,6 @@
 import { Document } from "mongoose";
 
-export interface Usuario extends Document {
+export interface IUsuario extends Document {
     nombre: string;
     apellido: string;
     email: string;

--- a/backend/src/models/publicacion.model.ts
+++ b/backend/src/models/publicacion.model.ts
@@ -1,13 +1,24 @@
-import { Publicacion } from "../interfaces/publicacion.interface";
+import { IPublicacion } from "@/interfaces/publicacion.interface";
 import { model, Schema } from 'mongoose';
 
+//schema comentario
+const comentarioSchema = new Schema({
+    autor: { type: String, required: true },
+    contenido: { type: String, required: true },
+    fecha: { type: Date, required: true }
+});
+
+
+//schema publicación
 const publicacionSchema = new Schema({
     titulo: { type: String, required: true },
     contenido: { type: String, required: true },
     //id del autor
     autor: { type: Schema.Types.ObjectId, ref: 'Usuario', required: true },
     fecha: { type: Date, required: true },
-    adjunto: { type: [String], required: false }
+    adjunto: { type: [String], required: false },
+    comentarios: { type: [comentarioSchema], required: false },
+    tag: { type: Date, required: true }
 });
 
-export const modelPublicacion = model<Publicacion>('Publicacion', publicacionSchema);
+export const modelPublicacion = model<IPublicacion>('Publicacion', publicacionSchema);

--- a/backend/src/models/usuario.model.ts
+++ b/backend/src/models/usuario.model.ts
@@ -1,4 +1,4 @@
-import { Usuario } from "../interfaces/usuario.interface";
+import { IUsuario } from "@/interfaces/usuario.interface";
 import {model, Schema} from 'mongoose';
 
 const usuarioSchema = new Schema({
@@ -8,4 +8,4 @@ const usuarioSchema = new Schema({
     password: {type: String, required: true}
 });
 
-export const modelUsuario =  model<Usuario>('Usuario', usuarioSchema);
+export const modelUsuario =  model<IUsuario>('Usuario', usuarioSchema);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -30,7 +30,9 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+     "paths": {
+      "@/*": ["./src/*"]
+     },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION


Rename `Usuario` and `Publicacion` interfaces to `IUsuario` and `IPublicacion` respectively to follow naming conventions.

Update import paths to use `@/*` alias for better maintainability.

Extend `IPublicacion` interface to include `IComentario` and `tag` fields, and update the corresponding model schema accordingly.