### PR TITLE
feat: add esAdmin and publicado fields to user and post models

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,9 @@
-import express,{Request,Response,Express} from 'express';
+import express, { Request, Response, Express } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import { connectBD } from './utils/mongodb';
-import usuarioRoutes from './routes/usuario.routes'; 
-import publicacionRoutes from './routes/publicaciones.routes'; 
+import usuarioRoutes from './routes/usuario.routes';
+import publicacionRoutes from './routes/publicaciones.routes';
 
 const app: Express = express();
 dotenv.config();
@@ -12,25 +12,25 @@ app.disable('x-powered-by');
 app.use(express.json());
 app.use(cors(
     {
-        origin:'*',
-        methods:['GET','POST','PUT','DELETE'],
-        credentials:true
+        origin: '*',
+        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        credentials: true
     }
 ));
 
 //routes
-app.use('/usuario',usuarioRoutes);
-app.use('/publicaciones',publicacionRoutes);
+app.use('/usuario', usuarioRoutes);
+app.use('/publicaciones', publicacionRoutes);
 
-app.get('/',(req:Request,res:Response)=>{
+app.get('/', (req: Request, res: Response) => {
     res.send('Hello World');
 });
 
 const port = process.env.PORT || 5000;
 
-connectBD(process.env.BD_URL || '').then(()=>{
+connectBD(process.env.BD_URL || '').then(() => {
     console.log('Connected to MongoDB');
-    app.listen(port,()=>{
+    app.listen(port, () => {
         console.log('Server is running on http://localhost:3000');
     });
 });

--- a/backend/src/interfaces/publicacion.interface.ts
+++ b/backend/src/interfaces/publicacion.interface.ts
@@ -8,6 +8,7 @@ export interface IPublicacion extends Document {
     adjunto: string[];
     comentarios: IComentario[]; // Array de comentarios
     tag: string;
+    publicado: boolean;
 }
 
 export interface IComentario {

--- a/backend/src/interfaces/usuario.interface.ts
+++ b/backend/src/interfaces/usuario.interface.ts
@@ -5,4 +5,5 @@ export interface IUsuario extends Document {
     apellido: string;
     email: string;
     password: string;
+    esAdmin: boolean;
 }

--- a/backend/src/models/publicacion.model.ts
+++ b/backend/src/models/publicacion.model.ts
@@ -18,7 +18,8 @@ const publicacionSchema = new Schema({
     fecha: { type: Date, required: true },
     adjunto: { type: [String], required: false },
     comentarios: { type: [comentarioSchema], required: false },
-    tag: { type: String, required: true }
+    tag: { type: String, required: true },
+    publicado: { type: Boolean, required: true }
 });
 
 export const modelPublicacion = model<IPublicacion>('Publicacion', publicacionSchema);

--- a/backend/src/models/usuario.model.ts
+++ b/backend/src/models/usuario.model.ts
@@ -1,11 +1,12 @@
 import { IUsuario } from "@/interfaces/usuario.interface";
-import {model, Schema} from 'mongoose';
+import { model, Schema } from 'mongoose';
 
 const usuarioSchema = new Schema({
-    nombre: {type: String, required: true},
-    apellido: {type: String, required: true},
-    email: {type: String, required: true},
-    password: {type: String, required: true}
+    nombre: { type: String, required: true },
+    apellido: { type: String, required: true },
+    email: { type: String, required: true },
+    password: { type: String, required: true },
+    esAdmin: { type: Boolean, required: true },
 });
 
-export const modelUsuario =  model<IUsuario>('Usuario', usuarioSchema);
+export const modelUsuario = model<IUsuario>('Usuario', usuarioSchema);


### PR DESCRIPTION
This commit introduces two new fields to the database models: `esAdmin` in the `Usuario` model to distinguish admin users and `publicado` in the `Publicacion` model to manage publication status. These changes enhance the application's functionality by enabling role-based access control and publication management.